### PR TITLE
Added sbt Junit config + (unfinished) Kima plugin test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,5 +15,8 @@ libraryDependencies ++= Seq()
 
 /** Test dependencies **/
 libraryDependencies ++= Seq(
-  "junit" % "junit" % "4.11" % "test"
+  "junit" % "junit" % "4.11" % "test",
+  "com.novocode" % "junit-interface" % "0.10" % "test"
 )
+
+testOptions += Tests.Argument(TestFrameworks.JUnit)

--- a/src/test/java/org/pelagios/recogito/sdk/examples/ner/KimaPluginTest.java
+++ b/src/test/java/org/pelagios/recogito/sdk/examples/ner/KimaPluginTest.java
@@ -1,0 +1,39 @@
+package org.pelagios.recogito.sdk.examples.ner;
+
+import static org.junit.Assert.*;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+import org.pelagios.recogito.sdk.examples.ner.ExampleKimaNERPlugin;
+import org.pelagios.recogito.sdk.ner.EntityType;
+import org.pelagios.recogito.sdk.ner.Entity;
+
+public class KimaPluginTest {
+
+  @Test
+  public void test() throws Exception {
+    Path path = Paths.get(getClass().getClassLoader()
+      .getResource("kima.txt").toURI());
+          
+    Stream<String> lines = Files.lines(path);
+    String data = lines.collect(Collectors.joining("\n"));
+    lines.close();
+
+    ExampleKimaNERPlugin plugin = new ExampleKimaNERPlugin();
+    List<Entity> entities = plugin.parse(data);
+
+    System.out.println(entities.toString());
+
+    /*
+    assertEquals(3, entities.size());
+    assertEquals(firstExpectedMatch, entities.get(0));
+    assertEquals(secondExpectedMatch, entities.get(1));
+    assertEquals(thirdExpectedMatch, entities.get(2));
+    */
+  }
+
+}


### PR DESCRIPTION
Just a bit of test code, so I could easily run the Kima plugin on my machine. Using the included test file (kima.txt) I currently get the following error:

```
[error] Test org.pelagios.recogito.sdk.examples.ner.KimaPluginTest.test failed: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
[error]     at java.lang.String.charAt(String.java:658)
[error]     at org.pelagios.recogito.sdk.examples.ner.HebMatcher.normalizeWord(HebMatcher.java:60)
[error]     at org.pelagios.recogito.sdk.examples.ner.HebMatcher.hasWord(HebMatcher.java:15)
[error]     at org.pelagios.recogito.sdk.examples.ner.ExampleKimaNERPlugin.parse(ExampleKimaNERPlugin.java:90)
[error]     at org.pelagios.recogito.sdk.examples.ner.KimaPluginTest.test(KimaPluginTest.java:27)
[error]     ...
[error] Failed: Total 2, Failed 1, Errors 0, Passed 1
```

I note that there are empty lines in the test file. I think that's what might be causing the HebMatcher to crash at the following line: 

```
char last = word.charAt(len - 1);
``` 